### PR TITLE
Add GermanQuAD dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If you want to build from source, use:
 
 ```python
 $ git clone https://github.com/benchmarkir/beir.git
+$ cd beir
 $ pip install -e .
 ```
 
@@ -186,6 +187,7 @@ For other datasets, just use one of the datasets names, mention below.
 | Climate-FEVER| [Homepage](http://climatefever.ai) | ``climate-fever``|  1,535     |  5.42M |  3.0 |  [Link](https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/climate-fever.zip)  | ``8b66f0a9126c521bae2bde127b4dc99d`` |
 | SciFact| [Homepage](https://github.com/allenai/scifact) | ``scifact``|  300     |  5K    |  1.1 |  [Link](https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/scifact.zip)  | ``5f7d1de60b170fc8027bb7898e2efca1`` |
 | Robust04 | [Homepage](https://trec.nist.gov/data/robust/04.guidelines.html) | ``robust04``|  249  |  528K  |  69.9 |  No  |  [How to Reproduce?](https://github.com/UKPLab/beir/blob/main/examples/dataset#3-robust04)  |
+| GermanQuAD | [Homepage](https://deepset.ai/germanquad) | ``germanquad``|  2044  |  2.80M  |  1.0 |  [Link](https://dpr-german.s3.eu-west-1.amazonaws.com/germanquad.zip)  | ``e7dedd97c26128a31493ef3e5fe2becf`` |
 
 Otherwise, you can load a custom preprocessed dataset in the following way:
 

--- a/examples/dataset/download_dataset.py
+++ b/examples/dataset/download_dataset.py
@@ -10,7 +10,7 @@ def main():
                      "nq.zip", "hotpotqa.zip", "fiqa.zip", "arguana.zip",
                      "webis-touche2020.zip", "cqadupstack.zip", "quora.zip",
                      "dbpedia-entity.zip", "scidocs.zip", "fever.zip",
-                     "climate-fever.zip", "scifact.zip]
+                     "climate-fever.zip", "scifact.zip", "germanquad.zip"]
     
     for dataset in dataset_files:
         

--- a/examples/dataset/md5.csv
+++ b/examples/dataset/md5.csv
@@ -14,3 +14,4 @@ scidocs.zip,38121350fc3a4d2f48850f6aff52e4a9
 fever.zip,88591ef8eb2913126d0c93ecbde6285f
 climate-fever.zip,8b66f0a9126c521bae2bde127b4dc99d
 scifact.zip,5f7d1de60b170fc8027bb7898e2efca1
+germanquad.zip,e7dedd97c26128a31493ef3e5fe2becf


### PR DESCRIPTION
It would be nice to include the GermanQuAD dataset that is based on the German Wikipedia and in-house question answering annotations we did at [deepset](https://deepset.ai/).
I uploaded the dataset [here](https://dpr-german.s3.eu-west-1.amazonaws.com/germanquad.zip).
Feel free to also host it at https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/
There is more information about the dataset here https://deepset.ai/germanquad and here https://arxiv.org/abs/2104.12741
Happy to answer any additional questions! I uploaded the files in the same format as described in the README.md with a corpus.jsonl, a queries.jsonl, and a directory qrels containing a test.tsv. 

I tested downloading and extracting the data with the following code. Right now I am encoding the corpus in batches... Indeed, it is taking a while (2.8 million passages)! 😄 
```
from beir import util
from beir.datasets.data_loader import GenericDataLoader

dataset = "scifact"
url = "https://dpr-german.s3.eu-west-1.amazonaws.com/germanquad.zip"
data_path = util.download_and_unzip(url, "datasets")
corpus, queries, qrels = GenericDataLoader(data_folder=data_path).load(split="test")
```

Let me know if there are any changes needed. Thank you!