### PR TITLE
Fix sparse search

### DIFF
--- a/beir/retrieval/search/sparse/sparse_search.py
+++ b/beir/retrieval/search/sparse/sparse_search.py
@@ -31,7 +31,7 @@ class SparseSearch:
             #Get the candidate passages
             scores = np.asarray(self.sparse_matrix[query_tokens, :].sum(axis=0)).squeeze(0)
             top_k_ind = np.argpartition(scores, -top_k)[-top_k:]
-            self.results[qid] = {doc_ids[pid]: float(scores[pid]) for pid in top_k_ind}
+            self.results[qid] = {doc_ids[pid]: float(scores[pid]) for pid in top_k_ind if doc_ids[pid] != qid}
         
         return self.results
 

--- a/beir/retrieval/search/sparse/sparse_search.py
+++ b/beir/retrieval/search/sparse/sparse_search.py
@@ -25,7 +25,7 @@ class SparseSearch:
         self.sparse_matrix = self.model.encode_corpus(documents, batch_size=self.batch_size)
         
         logging.info("Starting to Retrieve...")
-        for start_idx in trange(0, len(queries), self.batch_size, desc='query'):
+        for start_idx in trange(0, len(queries), desc='query'):
             qid = query_ids[start_idx]
             query_tokens = self.model.encode_query(queries[qid])
             #Get the candidate passages


### PR DESCRIPTION
Hi,

This pull request fixes two issues with the sparse search:

1. Because of the step in `trange`, some queries are never evaluated (only the first one of each batch is evaluated) as reported in #60.
2. Dense search skips some results (see [here](https://github.com/UKPLab/beir/blob/568f4c34fa0be1901e2aaa8479978c9e54a1e377/beir/retrieval/search/dense/exact_search.py#L77)), this was not implemented in the sparse search. It impacts the results on ArguAna and Quora (#37)

Let me know if you have any questions.

Maxime.