### PR TITLE
Sparse query vector

### DIFF
--- a/beir/retrieval/models/__init__.py
+++ b/beir/retrieval/models/__init__.py
@@ -3,3 +3,4 @@ from .use_qa import UseQA
 from .sparta import SPARTA
 from .dpr import DPR
 from .bpr import BinarySentenceBERT
+from .splade import SPLADE

--- a/beir/retrieval/models/splade.py
+++ b/beir/retrieval/models/splade.py
@@ -1,0 +1,46 @@
+from typing import List, Dict
+
+
+import tqdm
+import torch
+import numpy as np
+import transformers
+from scipy import sparse
+
+
+class SPLADE:
+    def __init__(self, model_name_or_path, max_length=256):
+        self.model = transformers.AutoModelForMaskedLM.from_pretrained(model_name_or_path)
+        self.tokenizer = transformers.AutoTokenizer.from_pretrained(model_name_or_path)
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.model.to(self.device)
+        self.max_length = max_length
+
+    def encode(self, text):
+        inputs = self.tokenizer(text, max_length=self.max_length, padding=True, truncation=True, return_tensors="pt").to(self.device)
+        with torch.no_grad():
+            outputs = self.model(**inputs)
+            token_embeddings = outputs[0]
+            attention_mask = inputs["attention_mask"]
+            sentence_embedding = torch.max(torch.log(1 + torch.relu(token_embeddings)) * attention_mask.unsqueeze(-1), dim=1).values
+        return sentence_embedding.cpu().numpy()
+
+    def encode_query(self, query: str, **kwargs) -> sparse.csr_matrix:
+        """ returns a csr_matrix of shape [1, n_vocab] """
+        output = self.encode(query)
+        return sparse.csr_matrix(output)
+        
+    def encode_corpus(self, corpus: List[Dict[str, str]], batch_size: int, **kwargs) -> sparse.csr_matrix:
+        """ returns a csr_matrix of shape [n_documents, n_vocab] """
+        data, row, col = [], [], []
+        sentences = [(doc["title"] + " " + doc["text"]).strip() for doc in corpus]
+        for i in tqdm.tqdm(range(0, len(sentences), batch_size), desc="encode_corpus"):
+            batch = sentences[i:i+batch_size]
+            dense = self.encode(batch)
+            sparse_mat = sparse.coo_matrix(dense)
+            data.extend(sparse_mat.data)
+            row.extend(sparse_mat.row + i)
+            col.extend(sparse_mat.col)
+        shape = (max(row)+1, self.model.config.vocab_size)
+        results = sparse.csr_matrix((data, (row, col)), shape=shape, dtype=np.float)
+        return results

--- a/beir/retrieval/search/sparse/sparse_search.py
+++ b/beir/retrieval/search/sparse/sparse_search.py
@@ -31,7 +31,7 @@ class SparseSearch:
             #Get the candidate passages
             scores = np.asarray(self.sparse_matrix[query_tokens, :].sum(axis=0)).squeeze(0)
             top_k_ind = np.argpartition(scores, -top_k)[-top_k:]
-            self.results[qid] = {doc_ids[pid]: float(scores[pid]) for pid in top_k_ind}
+            self.results[qid] = {doc_ids[pid]: float(scores[pid]) for pid in top_k_ind if doc_ids[pid] != qid}
         
         return self.results
 

--- a/beir/retrieval/search/sparse/sparse_search.py
+++ b/beir/retrieval/search/sparse/sparse_search.py
@@ -25,7 +25,7 @@ class SparseSearch:
         self.sparse_matrix = self.model.encode_corpus(documents, batch_size=self.batch_size)
         
         logging.info("Starting to Retrieve...")
-        for start_idx in trange(0, len(queries), self.batch_size, desc='query'):
+        for start_idx in trange(0, len(queries), desc='query'):
             qid = query_ids[start_idx]
             query_tokens = self.model.encode_query(queries[qid])
             #Get the candidate passages

--- a/examples/retrieval/evaluation/sparse/evaluate_splade.py
+++ b/examples/retrieval/evaluation/sparse/evaluate_splade.py
@@ -1,0 +1,64 @@
+from beir import util, LoggingHandler
+from beir.retrieval import models
+from beir.datasets.data_loader import GenericDataLoader
+from beir.retrieval.evaluation import EvaluateRetrieval
+from beir.retrieval.search.sparse import SparseSearch
+
+import logging
+import pathlib, os
+import random
+import shutil
+
+#### Just some code to print debug information to stdout
+logging.basicConfig(format='%(asctime)s - %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S',
+                    level=logging.INFO,
+                    handlers=[LoggingHandler()])
+#### /print debug information to stdout
+
+dataset = "scifact"
+
+#### Download scifact dataset and unzip the dataset
+url = "https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/{}.zip".format(dataset)
+out_dir = os.path.join(pathlib.Path(__file__).parent.absolute(), "datasets")
+data_path = util.download_and_unzip(url, out_dir)
+
+#### Provide the data path where scifact has been downloaded and unzipped to the data loader
+# data folder would contain these files: 
+# (1) scifact/corpus.jsonl  (format: jsonlines)
+# (2) scifact/queries.jsonl (format: jsonlines)
+# (3) scifact/qrels/test.tsv (format: tsv ("\t"))
+
+corpus, queries, qrels = GenericDataLoader(data_folder=data_path).load(split="test")
+
+#### Sparse Retrieval using SPLADE ####
+url = "https://download-de.europe.naverlabs.com/Splade_Release_Jan22/splade_distil_CoCodenser_large.tar.gz" 
+out_dir = os.path.join(pathlib.Path(__file__).parent.absolute(), "weights")
+os.makedirs(out_dir, exist_ok=True)
+filename = os.path.join(out_dir, "splade.tar.gz")
+model_dir = os.path.join(out_dir, "splade_distil_CoCodenser_large")
+if not os.path.exists(model_dir):
+    util.download_url(url, filename)
+    shutil.unpack_archive(filename, out_dir)
+sparse_model = SparseSearch(models.SPLADE(model_dir, max_length=256), batch_size=24)
+retriever = EvaluateRetrieval(sparse_model)
+
+#### Retrieve dense results (format of results is identical to qrels)
+results = retriever.retrieve(corpus, queries)
+
+#### Evaluate your retrieval using NDCG@k, MAP@K ...
+
+logging.info("Retriever evaluation for k in: {}".format(retriever.k_values))
+ndcg, _map, recall, precision = retriever.evaluate(qrels, results, retriever.k_values)
+
+#### Print top-k documents retrieved ####
+top_k = 10
+
+query_id, ranking_scores = random.choice(list(results.items()))
+scores_sorted = sorted(ranking_scores.items(), key=lambda item: item[1], reverse=True)
+logging.info("Query : %s\n" % queries[query_id])
+
+for rank in range(top_k):
+    doc_id = scores_sorted[rank][0]
+    # Format: Rank x: ID [Title] Body
+    logging.info("Rank %d: %s [%s] - %s\n" % (rank+1, doc_id, corpus[doc_id].get("title"), corpus[doc_id].get("text")))


### PR DESCRIPTION
This PR builds upon #62.

It refactors the sparse search to represent queries and documents as CSR matrices.

It also adds a clean SPLADE model along with an eval code. The SPLADE authors used a `DenseRetrievalExactSearch` in their demo script, but as SPLADE is labeled as a sparse model it should use a `SparseSearch` in my opinion. The results are not directly comparable as it uses the co-condenser instead of distilbert as base model. I could not find an URL to download the link of the original model.

 Maxime.