### PR TITLE
Fix incorrect import paths within apis package

### DIFF
--- a/beir/retrieval/apis/cohere.py
+++ b/beir/retrieval/apis/cohere.py
@@ -15,7 +15,7 @@ import torch.nn.functional as F
 from torch import Tensor
 from tqdm.autonotebook import trange
 
-from .util import extract_corpus_sentences
+from ..models.util import extract_corpus_sentences
 
 logger = logging.getLogger(__name__)
 

--- a/beir/retrieval/apis/voyage.py
+++ b/beir/retrieval/apis/voyage.py
@@ -14,7 +14,7 @@ import torch.nn.functional as F
 from torch import Tensor
 from tqdm.autonotebook import trange
 
-from .util import extract_corpus_sentences
+from ..models.util import extract_corpus_sentences
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
When running beir with APIs, the following error occurs due to incorrect import paths for `util`:

```
$ python examples/retrieval/evaluation/apis/evaluate_cohere.py
Traceback (most recent call last):
  File "/home/n0gu/beir/examples/retrieval/evaluation/apis/evaluate_cohere.py", line 19, in <module>
    from beir.retrieval import apis
  File "/home/n0gu/beir/beir/retrieval/apis/__init__.py", line 3, in <module>
    from .cohere import CohereEmbedAPI
  File "/home/n0gu/beir/beir/retrieval/apis/cohere.py", line 18, in <module>
    from .util import extract_corpus_sentences
ModuleNotFoundError: No module named 'beir.retrieval.apis.util'
```

This PR fixes the issue by correcting the import path to the appropriate location.

It might also make sense to move `extract_corpus_sentences` to `beir.util` instead of `beir.retrieval.models.util`. I wasn’t sure about the best location, so I made this change for now. Please feel free to suggest or request a refactor if you think it should go in `beir.util` instead.