### PR TITLE
Fix missing importlib.util import in exact_search.py

### DIFF
--- a/beir/retrieval/search/dense/exact_search.py
+++ b/beir/retrieval/search/dense/exact_search.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import heapq
-import importlib
+import importlib.util
 import logging
 import os
 


### PR DESCRIPTION
## Description

This PR fixes an `AttributeError: module 'importlib' has no attribute 'util'` that occurs when importing `DenseRetrievalExactSearch`.

## Problem

Previously when using `DenseRetrievalExactSearch`, I encountered the following error:

```python
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "beir/retrieval/search/dense/__init__.py", line 3, in <module>
    from .exact_search import DenseRetrievalExactSearch
  File "beir/retrieval/search/dense/exact_search.py", line 8, in <module>
    if importlib.util.find_spec("faiss") is not None:
       ^^^^^^^^^^^^^^
AttributeError: module 'importlib' has no attribute 'util'
```

After investigation, I found the file `beir/retrieval/search/dense/exact_search.py` currently imports only the `importlib` module but attempts to use `importlib.util.find_spec()`. In Python, importing a parent module does not automatically import its submodules, leading to an AttributeError.

## Solution

Explicitly import the `importlib.util` submodule:

```python
import importlib.util
```

This is consistent with other files in the codebase (e.g., `faiss_search.py`, `faiss_index.py`) that already use the correct import.

## Test Environment

- Python: 3.12
- BEIR: 2.2.0+
- OS: macOS